### PR TITLE
Kick players if they're inactive for more than 24h

### DIFF
--- a/server.py
+++ b/server.py
@@ -181,9 +181,6 @@ class GameServer:
             if os.path.isdir("players/" + player):
                 x = int(open("players/" + player + "/x").read().strip())
                 y = int(open("players/" + player + "/y").read().strip())
-                if not os.path.isfile("players/" + player + "/timestamp"):
-                    open("players/" + player + "/timestamp", "w").write(str(time.time()))
-                lastActive = float(open("players/" + player + "/timestamp").read().strip())
 
                 # player input
                 action = self.getPlayerAction(player)
@@ -199,10 +196,15 @@ class GameServer:
                 elif action == "idle":
                     self.log(player + " didn't do anything")
                 else:
-                    if time.time() - lastActive > 86400: # 24h
-                        self.log(player + " was kicked - no valid command for 24 hours")
-                    else:
-                        self.log(player + " isn't playing")
+                    self.log(player + " isn't playing")
+
+                # kick inactive players
+                if not os.path.isfile("players/" + player + "/timestamp"):
+                    open("players/" + player + "/timestamp", "w").write(str(time.time()))
+                lastActive = float(open("players/" + player + "/timestamp").read().strip())
+
+                if time.time() - lastActive > 86400: # 24h
+                    self.log(player + " was kicked - no activity for 24 hours")
 
                 # reload after player moves
                 icon = open("players/" + player + "/team").read().strip()

--- a/server.py
+++ b/server.py
@@ -210,7 +210,7 @@ class GameServer:
 
                 if time.time() - lastActive > 86400: # 24h
                     self.log(player + " was kicked - no activity for 24 hours")
-                    # TODO: Actually kick the player
+                    self.clearPlayerData(player):
 
                 world[y][x] = icon
 

--- a/server.py
+++ b/server.py
@@ -181,6 +181,10 @@ class GameServer:
             if os.path.isdir("players/" + player):
                 x = int(open("players/" + player + "/x").read().strip())
                 y = int(open("players/" + player + "/y").read().strip())
+                if not os.path.isfile("players/" + player + "/timestamp"):
+                    open("players/" + player + "/timestamp", "w").write(str(time.time()))
+                lastActive = float(open("players/" + player + "/timestamp").read().strip())
+                kick = false
 
                 # player input
                 action = self.getPlayerAction(player)
@@ -196,7 +200,10 @@ class GameServer:
                 elif action == "idle":
                     self.log(player + " didn't do anything")
                 else:
-                    self.log(player + " isn't playing")
+                    if time.time() - lastActive > 86400: # 24h
+                        self.log(player + " was kicked - no valid command for 24 hours")
+                    else:
+                        self.log(player + " isn't playing")
 
                 # reload after player moves
                 icon = open("players/" + player + "/team").read().strip()
@@ -204,13 +211,10 @@ class GameServer:
                 y = int(open("players/" + player + "/y").read().strip())
 
                 # kick inactive players
-                if not os.path.isfile("players/" + player + "/timestamp"):
-                    open("players/" + player + "/timestamp", "w").write(str(time.time()))
-                lastActive = float(open("players/" + player + "/timestamp").read().strip())
-
-                if time.time() - lastActive > 86400: # 24h
-                    self.log(player + " was kicked - no activity for 24 hours")
-                    self.clearPlayerData(player):
+                if time.time() - lastActive > 259200: # 72h
+                    self.log(player + " was kicked - no activity for 72 hours")
+                if kick:
+                    self.clearPlayerData(player)
 
                 world[y][x] = icon
 

--- a/server.py
+++ b/server.py
@@ -198,15 +198,15 @@ class GameServer:
                 else:
                     self.log(player + " isn't playing")
 
-                # kick inactive players
-                if not os.path.isfile("players/" + player + "/timestamp"):
-                    open("players/" + player + "/timestamp", "w").write(str(time.time()))
-                lastActive = float(open("players/" + player + "/timestamp").read().strip())
-
                 # reload after player moves
                 icon = open("players/" + player + "/team").read().strip()
                 x = int(open("players/" + player + "/x").read().strip())
                 y = int(open("players/" + player + "/y").read().strip())
+
+                # kick inactive players
+                if not os.path.isfile("players/" + player + "/timestamp"):
+                    open("players/" + player + "/timestamp", "w").write(str(time.time()))
+                lastActive = float(open("players/" + player + "/timestamp").read().strip())
 
                 if time.time() - lastActive > 86400: # 24h
                     self.log(player + " was kicked - no activity for 24 hours")

--- a/server.py
+++ b/server.py
@@ -203,13 +203,14 @@ class GameServer:
                     open("players/" + player + "/timestamp", "w").write(str(time.time()))
                 lastActive = float(open("players/" + player + "/timestamp").read().strip())
 
-                if time.time() - lastActive > 86400: # 24h
-                    self.log(player + " was kicked - no activity for 24 hours")
-
                 # reload after player moves
                 icon = open("players/" + player + "/team").read().strip()
                 x = int(open("players/" + player + "/x").read().strip())
                 y = int(open("players/" + player + "/y").read().strip())
+
+                if time.time() - lastActive > 86400: # 24h
+                    self.log(player + " was kicked - no activity for 24 hours")
+                    # TODO: Actually kick the player
 
                 world[y][x] = icon
 

--- a/server.py
+++ b/server.py
@@ -202,6 +202,7 @@ class GameServer:
                 else:
                     if time.time() - lastActive > 86400: # 24h
                         self.log(player + " was kicked - no valid command for 24 hours")
+                        kick = true
                     else:
                         self.log(player + " isn't playing")
 
@@ -213,6 +214,7 @@ class GameServer:
                 # kick inactive players
                 if time.time() - lastActive > 259200: # 72h
                     self.log(player + " was kicked - no activity for 72 hours")
+                    kick = true
                 if kick:
                     self.clearPlayerData(player)
 

--- a/server.py
+++ b/server.py
@@ -184,7 +184,7 @@ class GameServer:
                 if not os.path.isfile("players/" + player + "/timestamp"):
                     open("players/" + player + "/timestamp", "w").write(str(time.time()))
                 lastActive = float(open("players/" + player + "/timestamp").read().strip())
-                kick = false
+                kick = False
 
                 # player input
                 action = self.getPlayerAction(player)
@@ -202,7 +202,7 @@ class GameServer:
                 else:
                     if time.time() - lastActive > 86400: # 24h
                         self.log(player + " was kicked - no valid command for 24 hours")
-                        kick = true
+                        kick = True
                     else:
                         self.log(player + " isn't playing")
 
@@ -214,7 +214,7 @@ class GameServer:
                 # kick inactive players
                 if time.time() - lastActive > 259200: # 72h
                     self.log(player + " was kicked - no activity for 72 hours")
-                    kick = true
+                    kick = True
                 if kick:
                     self.clearPlayerData(player)
 

--- a/server.py
+++ b/server.py
@@ -217,6 +217,7 @@ class GameServer:
                     kick = True
                 if kick:
                     self.clearPlayerData(player)
+                    icon = icon.replace("c", "u")
 
                 world[y][x] = icon
 


### PR DESCRIPTION
As commented on #66 

The timestamp file is updated only if a player successfully move, therefor we could kick any players that stop being active or stuck.